### PR TITLE
[Refactor] Gallery 페이지당 불러오는 이미지 사이즈 조절

### DIFF
--- a/core/data/src/main/java/com/ham/icec/compose/data/datasource/local/GalleryDataSource.kt
+++ b/core/data/src/main/java/com/ham/icec/compose/data/datasource/local/GalleryDataSource.kt
@@ -5,6 +5,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface GalleryDataSource {
 
-    fun fetchGalleryImages(page: Int): Flow<List<GalleryImageInfo>>
+    fun fetchMediaStoreImages(page: Int): Flow<List<GalleryImageInfo>>
 
 }

--- a/core/data/src/main/java/com/ham/icec/compose/data/gallery/repository/GalleryRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ham/icec/compose/data/gallery/repository/GalleryRepositoryImpl.kt
@@ -13,8 +13,6 @@ class GalleryRepositoryImpl @Inject constructor(
 ) : GalleryRepository {
 
     override fun loadLocalImages(page: Int): Flow<List<Image>> =
-        localImageDataSource.fetchGalleryImages(page = page).map {
-            it.toDomain()
-        }
+        localImageDataSource.fetchMediaStoreImages(page = page).map { it.toDomain() }
 
 }

--- a/feat/gallery/src/main/kotlin/com/ham/icec/compose/gallery/GalleryViewModel.kt
+++ b/feat/gallery/src/main/kotlin/com/ham/icec/compose/gallery/GalleryViewModel.kt
@@ -39,7 +39,7 @@ class GalleryViewModel @Inject constructor(
             }.collect { newImages ->
                 val currentImages = _uiState.value.galleryImages
 
-                if (newImages.size < 20) {
+                if (newImages.size < 30) {
                     _uiState.value = _uiState.value.copy(
                         isLastPage = true,
                         galleryImages = currentImages + newImages


### PR DESCRIPTION
## 변경 사유

- 일부 높이가 긴 디바이스에서 스크롤시 페이지를 불러오지 못하는 현상 발생
- 임계값 영역에 닿지 않아 페이지를 불러오지 못하는 오류
```
private const val THRESHOLD = 15

val derivedStateOf = remember(galleryImages) { derivedStateOf { lazyGridState.firstVisibleItemIndex >= galleryImages.size - THRESHOLD } }

LaunchedEffect(derivedStateOf.value) {
        if (derivedStateOf.value && isLastPage.not() && galleryImages.isNotEmpty()) {
            onNextPageImages()
        }
    }
```